### PR TITLE
error align for bootstrap textarea element

### DIFF
--- a/src/ReverseForm/Renderer.php
+++ b/src/ReverseForm/Renderer.php
@@ -24,6 +24,7 @@ class Renderer implements ServiceManagerAwareInterface
     public $globalFormConfig = array();
     
     protected $escapeHtmlHelper;
+    protected $labelHelper;
 
     public function setFormStyle($formStyle)
     {

--- a/src/ReverseForm/Renderer/Bootstrap.php
+++ b/src/ReverseForm/Renderer/Bootstrap.php
@@ -102,6 +102,8 @@ class Bootstrap extends Renderer
             $label = $element->getLabel();
             if (!empty($label)) {
                 $label = $escapeHtmlHelper($label);
+                $labelTranslator = $this->getLabelHelper()->getTranslator();
+                if ($labelTranslator) $label = $labelTranslator->translate($label);
                 $markup = sprintf(
                     '<fieldset><legend>%s</legend>%s</fieldset>', $label, $markup
                 );

--- a/src/ReverseForm/Renderer/Bootstrap.php
+++ b/src/ReverseForm/Renderer/Bootstrap.php
@@ -13,58 +13,55 @@ class Bootstrap extends Renderer
     public function setFormStyle($formStyle)
     {
 
-        switch($formStyle)
-        {
+        switch ($formStyle) {
             case 'vertical':
                 $this->_formStyle = '';
                 break;
-            
+
             case 'horizontal':
                 $this->_formStyle = 'form-horizontal';
                 break;
         }
-        
-        $this->_form->setAttribute('class', $this->_form->getAttribute('class').' '.$this->_formStyle);
-        
+
+        $this->_form->setAttribute('class', $this->_form->getAttribute('class') . ' ' . $this->_formStyle);
+
         return $this;
-        
+
     }
-    
+
     public function formAction($fieldset)
     {
-        
+
         return $this->view->partial('bootstrap/formAction.phtml', array('element' => $fieldset));
-            
+
     }
 
     public function formRow($element)
     {
 
         $this->normalizeElement($element);
-        
-        if($element instanceOf ExtendedElement) {
-            if(isset($this->globalFormConfig[get_class($element)])){
+
+        if ($element instanceOf ExtendedElement) {
+            if (isset($this->globalFormConfig[get_class($element)])) {
                 $element->injectGlobalConfig(
-                        $this->globalFormConfig[get_class($element)]
+                    $this->globalFormConfig[get_class($element)]
                 );
             }
             $this->extractExtendedElementData($element);
             $element->injectSettings($this->getSettings());
         }
-        
+
         if ($element instanceof ExtendedElement AND $element->getTemplate()) {
             return $this->view->partial('bootstrap/' . $element->getTemplate(), array('element' => $element));
         }
 
-        if ($element->getAttribute('type') == 'checkbox' || $element->getAttribute('type') == 'radio') {
+        if (in_array($element->getAttribute('type'), array('checkbox', 'radio', 'multi_checkbox'))) {
             return $this->view->partial('bootstrap/checkbox.phtml', array('element' => $element));
         }
-
 
         if ($element->getAttribute('type') == 'select') {
             return $this->view->partial('bootstrap/select.phtml', array('element' => $element));
         }
-
 
         if ($element->getAttribute('type') == 'textarea') {
             return $this->view->partial('bootstrap/textarea.phtml', array('element' => $element));
@@ -72,7 +69,7 @@ class Bootstrap extends Renderer
 
         return $this->view->partial('bootstrap/input.phtml', array('element' => $element));
     }
-    
+
     public function formCaptcha($element)
     {
         $this->normalizeElement($element);
@@ -112,7 +109,7 @@ class Bootstrap extends Renderer
         }
 
         return $markup;
-        
+
     }
 
 }

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -40,6 +40,7 @@ $optionValues = $e->getOption('value_options');
                value="<?php echo $e->getCheckedValue(); ?>"
                <?php if ($e->getAttribute('class')): ?>class="<?php echo $e->getAttribute('class') ?>"<?php endif; ?>
                <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
+               <?php if ($e->getAttribute('disabled')): ?>disabled="disabled"<?php endif; ?>
         <?php else: ?>
         <label class="control-label">
             <?php if ($label): ?>

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -7,12 +7,14 @@
         $label = $labelHelperTranlator->translate($label, $labelHelper->getTranslatorTextDomain());
     }
     $extended = $e->getOption('extended');
-    if($e->getAttribute('type') == 'checkbox') {
+    if($e->getAttribute('type') == 'checkbox' || $e->getAttribute('type') == 'multi_checkbox') {
         $name = $e->getName().'[]';
         $values = $e->getValue();
+        $type = 'checkbox';
     } else {
         $name = $e->getName();
         $values = array(0 => $e->getValue());
+        $type = $e->getAttribute('type');
     }
     $err = (count($e->getMessages()) > 0) ? $e->getMessages() : false;
 
@@ -37,9 +39,12 @@
             <?php if($label) { ?><?php if($e->getAttribute('required') == 'required') { echo '<em>*</em>'; } ?><?= $label; ?><?php } ?>
         </label>
         <div class="controls">
+        <?php if ($e->useHiddenElement()): ?>
+            <input type="hidden" name="<?php echo $e->getName(); ?>" value="<?php echo $e->getUncheckedValue(); ?>"/>
+        <?php endif; ?>
         <?php foreach($optionValues as $value => $key) { ?>
-            <label class="<?= $e->getAttribute('type'); ?><?php if($extended['compact']) { echo ' inline'; } ?>">
-            <input type="<?= $e->getAttribute('type'); ?>"
+            <label class="<?= $type; ?><?php if($extended['compact']) { echo ' inline'; } ?>">
+            <input type="<?= $type; ?>"
                    value="<?= $value; ?>" <?php if(is_array($values) && in_array($value, $values)){ echo 'checked="checked"'; } ?>
                    name="<?= $name; ?>" id="<?= $this->slugify($e->getName().'-'.$value); ?>">
             <?php if($labelHelperTranlator) {

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -40,6 +40,7 @@ $optionValues = $e->getOption('value_options');
                value="<?php echo $e->getCheckedValue(); ?>"
                <?php if ($e->getAttribute('class')): ?>class="<?php echo $e->getAttribute('class') ?>"<?php endif; ?>
                <?php if ($e->getAttribute('disabled')): ?>disabled="disabled"<?php endif; ?>
+               <?php if ($e->getAttribute('readonly')): ?>readonly="readonly"<?php endif; ?>
                <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
         <?php else: ?>
         <label class="control-label">

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -15,24 +15,41 @@
         $values = array(0 => $e->getValue());
     }
     $err = (count($e->getMessages()) > 0) ? $e->getMessages() : false;
+
+    $optionValues = $e->getOption('value_options');
 ?>
 <div class="control-group">
-    <label class="control-label">
-        <?php if($label) { ?><?php if($e->getAttribute('required') == 'required') { echo '<em>*</em>'; } ?><?= $label; ?><?php } ?>
-    </label>
-    <div class="controls">
-    <?php foreach($e->getOption('value_options') as $value => $key) { ?>
-        <label class="<?= $e->getAttribute('type'); ?><?php if($extended['compact']) { echo ' inline'; } ?>">
-        <input type="<?= $e->getAttribute('type'); ?>"
-               value="<?= $value; ?>" <?php if(is_array($values) && in_array($value, $values)){ echo 'checked="checked"'; } ?> 
-               name="<?= $name; ?>" id="<?= $this->slugify($e->getName().'-'.$value); ?>">
-        <?php if($labelHelperTranlator) { 
-            echo $labelHelperTranlator->translate($key, $labelHelper->getTranslatorTextDomain());
-        } else {
-            echo $key;
-        } ?>
+    <?php if (empty($optionValues)): ?>
+        <label class="control-label" for="<?php echo $e->getAttribute('id') ?>">
+            <?php if($e->getAttribute('required') == 'required') echo '<em>*</em>'; ?><?php echo $label; ?>
         </label>
-    <?php } ?>
+        <div class="controls">
+            <?php if ($e->useHiddenElement()): ?>
+                <input type="hidden" name="<?php echo $e->getName(); ?>" value="<?php echo $e->getUncheckedValue(); ?>"/>
+            <?php endif; ?>
+            <input type="<?php echo $e->getAttribute('type'); ?>"
+                   id="<?php echo $e->getAttribute('id'); ?>"
+                   name="<?php echo $e->getName(); ?>"
+                   value="<?php echo $e->getCheckedValue(); ?>"
+                   <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
+    <?php else: ?>
+        <label class="control-label">
+            <?php if($label) { ?><?php if($e->getAttribute('required') == 'required') { echo '<em>*</em>'; } ?><?= $label; ?><?php } ?>
+        </label>
+        <div class="controls">
+        <?php foreach($optionValues as $value => $key) { ?>
+            <label class="<?= $e->getAttribute('type'); ?><?php if($extended['compact']) { echo ' inline'; } ?>">
+            <input type="<?= $e->getAttribute('type'); ?>"
+                   value="<?= $value; ?>" <?php if(is_array($values) && in_array($value, $values)){ echo 'checked="checked"'; } ?>
+                   name="<?= $name; ?>" id="<?= $this->slugify($e->getName().'-'.$value); ?>">
+            <?php if($labelHelperTranlator) {
+                echo $labelHelperTranlator->translate($key, $labelHelper->getTranslatorTextDomain());
+            } else {
+                echo $key;
+            } ?>
+            </label>
+        <?php } ?>
+    <?php endif; ?>
     <?php if(count($extended['help']) > 0) { ?>
     <span class="help-block">
         <?php if($labelHelperTranlator) { 

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -42,7 +42,6 @@
         } ?>
     </span>
     <?php } ?>
-    </div>
     <?php if($err) { ?>
     <ul>
     <?php foreach($err as $k => $v) { ?>
@@ -54,4 +53,5 @@
     <?php } ?>
     </ul>
     <?php } ?>
+    </div>
 </div>

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -1,79 +1,80 @@
 <?php
-    $e = $this->element;
-    $labelHelper = $this->formLabel();
-    $label = $e->getLabel();
-    $labelHelperTranlator = $labelHelper->getTranslator();
-    if($label AND $labelHelperTranlator) {
-        $label = $labelHelperTranlator->translate($label, $labelHelper->getTranslatorTextDomain());
-    }
-    $extended = $e->getOption('extended');
-    if($e->getAttribute('type') == 'checkbox' || $e->getAttribute('type') == 'multi_checkbox') {
-        $name = $e->getName().'[]';
-        $values = $e->getValue();
-        $type = 'checkbox';
-    } else {
-        $name = $e->getName();
-        $values = array(0 => $e->getValue());
-        $type = $e->getAttribute('type');
-    }
-    $err = (count($e->getMessages()) > 0) ? $e->getMessages() : false;
+/**
+ * @var $e \Zend\Form\Element\Checkbox
+ * @var $labelHelper \Zend\Form\View\Helper\FormLabel
+ */
+$e = $this->element;
+$labelHelper = $this->formLabel();
+$label = $e->getLabel();
+$labelHelperTranslator = $labelHelper->getTranslator();
+if ($label && $labelHelperTranslator) {
+    $label = $labelHelperTranslator->translate($label, $labelHelper->getTranslatorTextDomain());
+}
+$extended = $e->getOption('extended');
+if ($e->getAttribute('type') == 'checkbox' || $e->getAttribute('type') == 'multi_checkbox') {
+    $name = $e->getName() . '[]';
+    $values = $e->getValue();
+    $type = 'checkbox';
+} else {
+    $name = $e->getName();
+    $values = array(0 => $e->getValue());
+    $type = $e->getAttribute('type');
+}
+$err = (count($e->getMessages()) > 0) ? $e->getMessages() : false;
 
-    $optionValues = $e->getOption('value_options');
+$optionValues = $e->getOption('value_options');
 ?>
 <div class="control-group">
     <?php if (empty($optionValues)): ?>
-        <label class="control-label" for="<?php echo $e->getAttribute('id') ?>">
-            <?php if($e->getAttribute('required') == 'required') echo '<em>*</em>'; ?><?php echo $label; ?>
-        </label>
-        <div class="controls">
-            <?php if ($e->useHiddenElement()): ?>
-                <input type="hidden" name="<?php echo $e->getName(); ?>" value="<?php echo $e->getUncheckedValue(); ?>"/>
-            <?php endif; ?>
-            <input type="<?php echo $e->getAttribute('type'); ?>"
-                   id="<?php echo $e->getAttribute('id'); ?>"
-                   name="<?php echo $e->getName(); ?>"
-                   value="<?php echo $e->getCheckedValue(); ?>"
-                   <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
-    <?php else: ?>
-        <label class="control-label">
-            <?php if($label) { ?><?php if($e->getAttribute('required') == 'required') { echo '<em>*</em>'; } ?><?= $label; ?><?php } ?>
-        </label>
-        <div class="controls">
+    <label class="control-label" for="<?php echo $e->getAttribute('id') ?>">
+        <?php if ($e->getAttribute('required') == 'required') echo '<em>*</em>'; ?><?php echo $label; ?>
+    </label>
+
+    <div class="controls">
         <?php if ($e->useHiddenElement()): ?>
             <input type="hidden" name="<?php echo $e->getName(); ?>" value="<?php echo $e->getUncheckedValue(); ?>"/>
         <?php endif; ?>
-        <?php foreach($optionValues as $value => $key) { ?>
-            <label class="<?= $type; ?><?php if($extended['compact']) { echo ' inline'; } ?>">
-            <input type="<?= $type; ?>"
-                   value="<?= $value; ?>" <?php if(is_array($values) && in_array($value, $values)){ echo 'checked="checked"'; } ?>
-                   name="<?= $name; ?>" id="<?= $this->slugify($e->getName().'-'.$value); ?>">
-            <?php if($labelHelperTranlator) {
-                echo $labelHelperTranlator->translate($key, $labelHelper->getTranslatorTextDomain());
-            } else {
-                echo $key;
-            } ?>
-            </label>
-        <?php } ?>
-    <?php endif; ?>
-    <?php if(count($extended['help']) > 0) { ?>
-    <span class="help-block">
-        <?php if($labelHelperTranlator) { 
-            echo $labelHelperTranlator->translate($extended['help']['content'], $labelHelper->getTranslatorTextDomain());
-        } else {
-            echo $extended['help']['content'];
-        } ?>
-    </span>
-    <?php } ?>
-    <?php if($err) { ?>
-    <ul>
-    <?php foreach($err as $k => $v) { ?>
-    	<li><?php if($labelHelperTranlator) { 
-            echo $labelHelperTranlator->translate($v, $labelHelper->getTranslatorTextDomain());
-        } else {
-            echo $v;
-        } ?></li>
-    <?php } ?>
-    </ul>
-    <?php } ?>
+        <input type="<?php echo $e->getAttribute('type'); ?>"
+               id="<?php echo $e->getAttribute('id'); ?>"
+               name="<?php echo $e->getName(); ?>"
+               value="<?php echo $e->getCheckedValue(); ?>"
+               <?php if ($e->getAttribute('class')): ?>class="<?php echo $e->getAttribute('class') ?>"<?php endif; ?>
+               <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
+        <?php else: ?>
+        <label class="control-label">
+            <?php if ($label): ?>
+                <?php if ($e->getAttribute('required')) echo '<em>*</em>'; ?><?php echo $label; ?>
+            <?php endif; ?>
+        </label>
+
+        <div class="controls">
+            <?php if ($e->useHiddenElement()): ?>
+                <input type="hidden" name="<?php echo $e->getName(); ?>"
+                       value="<?php echo $e->getUncheckedValue(); ?>"/>
+            <?php endif; ?>
+            <?php foreach ($optionValues as $value => $key): ?>
+                <label class="<?php echo $type; ?><?php if ($extended['compact']) echo ' inline'; ?>">
+                    <input type="<?php echo $type; ?>"
+                           value="<?php echo $value; ?>"
+                           name="<?php echo $name; ?>" id="<?php echo $this->slugify($e->getName() . '-' . $value); ?>"
+                        <?php if (is_array($values) && in_array($value, $values)) echo 'checked="checked"'; ?>>
+                    <?php echo $labelHelperTranslator ? $labelHelperTranslator->translate($key, $labelHelper->getTranslatorTextDomain()) : $key ?>
+                </label>
+            <?php endforeach; ?>
+            <?php endif; ?>
+            <?php if (count($extended['help'])): ?>
+                <span class="help-block">
+                    <?php $labelHelperTranslator ? $labelHelperTranslator->translate($extended['help']['content'], $labelHelper->getTranslatorTextDomain()) : $extended['help']['content'] ?>
+                </span>
+            <?php endif; ?>
+            <?php if ($err): ?>
+                <ul>
+                    <?php foreach ($err as $k => $v): ?>
+                        <li>
+                            <?php echo $labelHelperTranslator ? $labelHelperTranslator->translate($v, $labelHelper->getTranslatorTextDomain()) : $v ?>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </div>
     </div>
-</div>

--- a/view/element/bootstrap/checkbox.phtml
+++ b/view/element/bootstrap/checkbox.phtml
@@ -39,8 +39,8 @@ $optionValues = $e->getOption('value_options');
                name="<?php echo $e->getName(); ?>"
                value="<?php echo $e->getCheckedValue(); ?>"
                <?php if ($e->getAttribute('class')): ?>class="<?php echo $e->getAttribute('class') ?>"<?php endif; ?>
-               <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
                <?php if ($e->getAttribute('disabled')): ?>disabled="disabled"<?php endif; ?>
+               <?php if ($e->isChecked()): ?>checked="checked"<?php endif ?>/>
         <?php else: ?>
         <label class="control-label">
             <?php if ($label): ?>

--- a/view/element/bootstrap/select.phtml
+++ b/view/element/bootstrap/select.phtml
@@ -26,7 +26,6 @@
         } ?>
     </span>
     <?php } ?>
-    </div>
     <?php if($err) { ?>
     <ul>
     <?php foreach($err as $k => $v) { ?>
@@ -38,4 +37,5 @@
     <?php } ?>
     </ul>
     <?php } ?>
+    </div>
 </div>

--- a/view/element/bootstrap/textarea.phtml
+++ b/view/element/bootstrap/textarea.phtml
@@ -25,11 +25,10 @@
         } ?>
     </span>
     <?php } ?>
-    </div>
     <?php if($err) { ?>
     <ul>
     <?php foreach($err as $k => $v) { ?>
-    	<li><?php if($labelHelperTranlator) { 
+    	<li><?php if($labelHelperTranlator) {
             echo $labelHelperTranlator->translate($v, $labelHelper->getTranslatorTextDomain());
         } else {
             echo $v;
@@ -37,4 +36,5 @@
     <?php } ?>
     </ul>
     <?php } ?>
+    </div>
 </div>


### PR DESCRIPTION
Fix for #5

And the same for select and checkbox elements

Also found that checkbox renderer works correctly only with MultiCheckbox elements, but does not work with Сheckbox - only label was rendered. Added support for simple checkbox element, including hidden element usage.
