### PR TITLE
formCollection debug

### DIFF
--- a/src/ReverseForm/Renderer.php
+++ b/src/ReverseForm/Renderer.php
@@ -22,6 +22,8 @@ class Renderer implements ServiceManagerAwareInterface
 
     public $localConfig = array();
     public $globalFormConfig = array();
+    
+    protected $escapeHtmlHelper;
 
     public function setFormStyle($formStyle)
     {


### PR DESCRIPTION
no protected variable: $escapeHtmlHelper;
It displayed error:

Notice: Undefined property: ReverseForm\Renderer\Bootstrap::$escapeHtmlHelper in ../vendor/silvester/reverse-form/src/ReverseForm/Renderer.php on line 245

this corrects it.
