### PR TITLE
Hide "control-group" for Hidden elements 

### DIFF
--- a/view/element/bootstrap/input.phtml
+++ b/view/element/bootstrap/input.phtml
@@ -9,6 +9,10 @@
     $extended = $e->getOption('extended');
     $required = ($e->getAttribute('required') == 'required') ? 'required="required"' : false;
     $err = (count($e->getMessages()) > 0) ? $e->getMessages() : false;
+
+    if($e->getAttribute('type') == "hidden"){
+        echo $this->formInput($e);
+    }else{
 ?>
 
 <div class="control-group <?php if($err){ echo "error";}?>">
@@ -45,3 +49,4 @@
     <?php } ?>
     </div>
 </div>
+<?php } ?>


### PR DESCRIPTION
This commit hides every "control-group" div if it's an hidden element. Change for bootstrap form.
